### PR TITLE
update inheritance

### DIFF
--- a/disaster_recovery_policy.md
+++ b/disaster_recovery_policy.md
@@ -1,6 +1,6 @@
 # Disaster Recover Policy
 
-The Catalyze Contingency Plan establishes procedures to recover Catalyze following a disruption resulting from a disaster. This policy, and associated procedures, do not apply to PaaS Customers that do not choose Catalyze Disaster Recovery Service. This Disaster Recovery Policy is maintained by the Catalyze Security Officer and Privacy Officer.
+The Catalyze Contingency Plan establishes procedures to recover Catalyze following a disruption resulting from a disaster. This Disaster Recovery Policy is maintained by the Catalyze Security Officer and Privacy Officer.
 
 The following objectives have been established for this plan: 
 

--- a/hipaa_inheritance_for_paas_customers.md
+++ b/hipaa_inheritance_for_paas_customers.md
@@ -7,8 +7,8 @@ Assigned Security Responsibility - 164.308(a)(2) | Roles Policy | Partially
 Workforce Security - 164.308(a)(3)(i) | Employee Policies | Partially
 Information Access Management - 164.308(a)(4)(i) | System Access Policy | Yes
 Security Awareness and Training - 164.308(a)(5)(i) | Employee Policy | No
-Security Incident Procedures - 164.308(a)(6)(i) | IDS Policy | Yes (optional)
-Contingency Plan - 164.308(a)(7)(i) | Disaster Recovery Policy | Yes (optional)
+Security Incident Procedures - 164.308(a)(6)(i) | IDS Policy | Yes
+Contingency Plan - 164.308(a)(7)(i) | Disaster Recovery Policy | Yes
 Evaluation - 164.308(a)(8) | Auditing Policy | Yes
 
 | **Physical Safeguards** HIPAA Rule | Catalyze Control | Inherited


### PR DESCRIPTION
Travis told me that the policies are outdated and all PaaS customers inherit the disaster recovery and IDS stuff automatically. This fixes the documentation.