### PR TITLE
Removing Asset Hash

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -11,7 +11,6 @@ activate :directory_indexes
 configure :build do
   activate :minify_css
   activate :minify_javascript
-  activate :asset_hash
 end
 
 set :markdown_engine, :redcarpet


### PR DESCRIPTION
Asset hash was impairing my ability to use assets externally. Considering we only have one image and minimal CSS, I think we can get by without asset hashing for now. Will consider re-adding in the future of performance is lacking.